### PR TITLE
Refactoring Kata

### DIFF
--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -14,6 +14,7 @@ enum Items {
   Brie = 'Aged Brie',
   Pass = 'Backstage passes to a TAFKAL80ETC concert',
   Sulfuras = 'Sulfuras, Hand of Ragnaros',
+  Conjured = 'Conjured Mana Cake',
 }
 
 const increaseQuality = (item: Item, increaseBy: number): Item => {
@@ -65,6 +66,14 @@ export class GildedRose {
           break;
         case Items.Sulfuras:
           // do not change item as it is legendary
+          break;
+        case Items.Conjured:
+          if (item.sellIn <=0) {
+            item = decreaseQuality(item, 4);
+          } else {
+            item = decreaseQuality(item, 2);
+          }
+          item.sellIn --;
           break;
         default:
           if (item.sellIn <= 0) {

--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -1,4 +1,10 @@
-import { Items, decreaseQuality, increaseQuality } from "./helpers";
+import {
+  Items,
+  updateBrie,
+  updateConjured,
+  updateDefault,
+  updatePass
+} from "./helpers";
 
 export class Item {
   name: string;
@@ -23,45 +29,19 @@ export class GildedRose {
     for (let item of this.items) {
       switch (item.name) {
         case Items.Brie:
-          if (item.sellIn <= 0) {
-            item = increaseQuality(item, 2);
-          } else {
-            item = increaseQuality(item, 1);
-          }
-          item.sellIn --;
+          updateBrie(item);
           break;
         case Items.Pass:
-          if (item.sellIn <= 0) {
-            item.quality = 0;
-          } else if (item.sellIn <= 5) {
-            item = increaseQuality(item, 3);
-          } else if (item.sellIn <= 10) {
-            item = increaseQuality(item, 2);
-          } else {
-            item = increaseQuality(item, 1);
-          }
-          item.sellIn --;
+          updatePass(item);
           break;
         case Items.Sulfuras:
           // do not change item as it is legendary
           break;
         case Items.Conjured:
-          // making the assumption that because "Conjured" items decrease in value twice as fast,
-          // the amount of quality decreased after passing the sell by also doubles
-          if (item.sellIn <=0) {
-            item = decreaseQuality(item, 4);
-          } else {
-            item = decreaseQuality(item, 2);
-          }
-          item.sellIn --;
+          updateConjured(item);
           break;
         default:
-          if (item.sellIn <= 0) {
-            item = decreaseQuality(item, 2);
-          } else {
-            item = decreaseQuality(item, 1);
-          }
-          item.sellIn --;
+          updateDefault(item);
           break;
       }
     }

--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -10,6 +10,12 @@ export class Item {
   }
 }
 
+enum Items {
+  Brie = 'Aged Brie',
+  Pass = 'Backstage passes to a TAFKAL80ETC concert',
+  Sulfuras = 'Sulfuras, Hand of Ragnaros',
+}
+
 export class GildedRose {
   items: Array<Item>;
 
@@ -19,16 +25,16 @@ export class GildedRose {
 
   updateQuality() {
     for (let i = 0; i < this.items.length; i++) {
-      if (this.items[i].name != 'Aged Brie' && this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
+      if (this.items[i].name != Items.Brie && this.items[i].name != Items.Pass) {
         if (this.items[i].quality > 0) {
-          if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
+          if (this.items[i].name != Items.Sulfuras) {
             this.items[i].quality = this.items[i].quality - 1
           }
         }
       } else {
         if (this.items[i].quality < 50) {
           this.items[i].quality = this.items[i].quality + 1
-          if (this.items[i].name == 'Backstage passes to a TAFKAL80ETC concert') {
+          if (this.items[i].name == Items.Pass) {
             if (this.items[i].sellIn < 11) {
               if (this.items[i].quality < 50) {
                 this.items[i].quality = this.items[i].quality + 1
@@ -42,14 +48,14 @@ export class GildedRose {
           }
         }
       }
-      if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
+      if (this.items[i].name != Items.Sulfuras) {
         this.items[i].sellIn = this.items[i].sellIn - 1;
       }
       if (this.items[i].sellIn < 0) {
-        if (this.items[i].name != 'Aged Brie') {
-          if (this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
+        if (this.items[i].name != Items.Brie) {
+          if (this.items[i].name != Items.Pass) {
             if (this.items[i].quality > 0) {
-              if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
+              if (this.items[i].name != Items.Sulfuras) {
                 this.items[i].quality = this.items[i].quality - 1
               }
             }

--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -52,6 +52,16 @@ export class GildedRose {
           item.sellIn --;
           break;
         case Items.Pass:
+          if (item.sellIn <= 0) {
+            item.quality = 0;
+          } else if (item.sellIn <= 5) {
+            item = increaseQuality(item, 3);
+          } else if (item.sellIn <= 10) {
+            item = increaseQuality(item, 2);
+          } else {
+            item = increaseQuality(item, 1);
+          }
+          item.sellIn --;
           break;
         case Items.Sulfuras:
           // do not change item as it is legendary
@@ -62,7 +72,7 @@ export class GildedRose {
           } else {
             item = decreaseQuality(item, 1);
           }
-          item.sellIn--;
+          item.sellIn --;
           break;
       }
 

--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -25,6 +25,18 @@ export class GildedRose {
 
   updateQuality() {
     for (const item of this.items) {
+
+      switch (item.name) {
+        case Items.Brie:
+          break;
+        case Items.Pass:
+          break;
+        case Items.Sulfuras:
+          break;
+        default:
+          break;
+      }
+
       if (item.name != Items.Brie && item.name != Items.Pass) {
         if (item.quality > 0) {
           if (item.name != Items.Sulfuras) {

--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -24,47 +24,47 @@ export class GildedRose {
   }
 
   updateQuality() {
-    for (let i = 0; i < this.items.length; i++) {
-      if (this.items[i].name != Items.Brie && this.items[i].name != Items.Pass) {
-        if (this.items[i].quality > 0) {
-          if (this.items[i].name != Items.Sulfuras) {
-            this.items[i].quality = this.items[i].quality - 1
+    for (const item of this.items) {
+      if (item.name != Items.Brie && item.name != Items.Pass) {
+        if (item.quality > 0) {
+          if (item.name != Items.Sulfuras) {
+            item.quality = item.quality - 1
           }
         }
       } else {
-        if (this.items[i].quality < 50) {
-          this.items[i].quality = this.items[i].quality + 1
-          if (this.items[i].name == Items.Pass) {
-            if (this.items[i].sellIn < 11) {
-              if (this.items[i].quality < 50) {
-                this.items[i].quality = this.items[i].quality + 1
+        if (item.quality < 50) {
+          item.quality = item.quality + 1
+          if (item.name == Items.Pass) {
+            if (item.sellIn < 11) {
+              if (item.quality < 50) {
+                item.quality = item.quality + 1
               }
             }
-            if (this.items[i].sellIn < 6) {
-              if (this.items[i].quality < 50) {
-                this.items[i].quality = this.items[i].quality + 1
+            if (item.sellIn < 6) {
+              if (item.quality < 50) {
+                item.quality = item.quality + 1
               }
             }
           }
         }
       }
-      if (this.items[i].name != Items.Sulfuras) {
-        this.items[i].sellIn = this.items[i].sellIn - 1;
+      if (item.name != Items.Sulfuras) {
+        item.sellIn = item.sellIn - 1;
       }
-      if (this.items[i].sellIn < 0) {
-        if (this.items[i].name != Items.Brie) {
-          if (this.items[i].name != Items.Pass) {
-            if (this.items[i].quality > 0) {
-              if (this.items[i].name != Items.Sulfuras) {
-                this.items[i].quality = this.items[i].quality - 1
+      if (item.sellIn < 0) {
+        if (item.name != Items.Brie) {
+          if (item.name != Items.Pass) {
+            if (item.quality > 0) {
+              if (item.name != Items.Sulfuras) {
+                item.quality = item.quality - 1
               }
             }
           } else {
-            this.items[i].quality = this.items[i].quality - this.items[i].quality
+            item.quality = item.quality - item.quality
           }
         } else {
-          if (this.items[i].quality < 50) {
-            this.items[i].quality = this.items[i].quality + 1
+          if (item.quality < 50) {
+            item.quality = item.quality + 1
           }
         }
       }

--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -44,6 +44,12 @@ export class GildedRose {
 
       switch (item.name) {
         case Items.Brie:
+          if (item.sellIn <= 0) {
+            item = increaseQuality(item, 2);
+          } else {
+            item = increaseQuality(item, 1);
+          }
+          item.sellIn --;
           break;
         case Items.Pass:
           break;

--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -48,6 +48,7 @@ export class GildedRose {
         case Items.Pass:
           break;
         case Items.Sulfuras:
+          // do not change item as it is legendary
           break;
         default:
           if (item.sellIn <= 0) {

--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -1,3 +1,5 @@
+import { Items, decreaseQuality, increaseQuality } from "./helpers";
+
 export class Item {
   name: string;
   sellIn: number;
@@ -8,29 +10,6 @@ export class Item {
     this.sellIn = sellIn;
     this.quality = quality;
   }
-}
-
-enum Items {
-  Brie = 'Aged Brie',
-  Pass = 'Backstage passes to a TAFKAL80ETC concert',
-  Sulfuras = 'Sulfuras, Hand of Ragnaros',
-  Conjured = 'Conjured Mana Cake',
-}
-
-const increaseQuality = (item: Item, increaseBy: number): Item => {
-  item.quality += increaseBy;
-  if (item.quality >= 50) {
-    item.quality = 50;
-  }
-  return item;
-}
-
-const decreaseQuality = (item: Item, decreaseBy: number): Item => {
-  item.quality -= decreaseBy;
-  if (item.quality < 0){
-    item.quality = 0;
-  }
-  return item;
 }
 
 export class GildedRose {

--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -40,7 +40,7 @@ export class GildedRose {
   }
 
   updateQuality() {
-    for (const item of this.items) {
+    for (let item of this.items) {
 
       switch (item.name) {
         case Items.Brie:
@@ -50,52 +50,59 @@ export class GildedRose {
         case Items.Sulfuras:
           break;
         default:
+          if (item.sellIn <= 0) {
+            item = decreaseQuality(item, 2);
+          } else {
+            item = decreaseQuality(item, 1);
+          }
+          item.sellIn--;
           break;
       }
 
-      if (item.name != Items.Brie && item.name != Items.Pass) {
-        if (item.quality > 0) {
-          if (item.name != Items.Sulfuras) {
-            item.quality = item.quality - 1
-          }
-        }
-      } else {
-        if (item.quality < 50) {
-          item.quality = item.quality + 1
-          if (item.name == Items.Pass) {
-            if (item.sellIn < 11) {
-              if (item.quality < 50) {
-                item.quality = item.quality + 1
-              }
-            }
-            if (item.sellIn < 6) {
-              if (item.quality < 50) {
-                item.quality = item.quality + 1
-              }
-            }
-          }
-        }
-      }
-      if (item.name != Items.Sulfuras) {
-        item.sellIn = item.sellIn - 1;
-      }
-      if (item.sellIn < 0) {
-        if (item.name != Items.Brie) {
-          if (item.name != Items.Pass) {
-            if (item.quality > 0) {
-              if (item.name != Items.Sulfuras) {
-                item.quality = item.quality - 1
-              }
-            }
-          } else {
-            item.quality = item.quality - item.quality
-          }
-        } else {
-          if (item.quality < 50) {
-            item.quality = item.quality + 1
-          }
-        }
-      }
+
+    //   if (item.name != Items.Brie && item.name != Items.Pass) {
+    //     if (item.quality > 0) {
+    //       if (item.name != Items.Sulfuras) {
+    //         item.quality = item.quality - 1
+    //       }
+    //     }
+    //   } else {
+    //     if (item.quality < 50) {
+    //       item.quality = item.quality + 1
+    //       if (item.name == Items.Pass) {
+    //         if (item.sellIn < 11) {
+    //           if (item.quality < 50) {
+    //             item.quality = item.quality + 1
+    //           }
+    //         }
+    //         if (item.sellIn < 6) {
+    //           if (item.quality < 50) {
+    //             item.quality = item.quality + 1
+    //           }
+    //         }
+    //       }
+    //     }
+    //   }
+    //   if (item.name != Items.Sulfuras) {
+    //     item.sellIn = item.sellIn - 1;
+    //   }
+    //   if (item.sellIn < 0) {
+    //     if (item.name != Items.Brie) {
+    //       if (item.name != Items.Pass) {
+    //         if (item.quality > 0) {
+    //           if (item.name != Items.Sulfuras) {
+    //             item.quality = item.quality - 1
+    //           }
+    //         }
+    //       } else {
+    //         item.quality = item.quality - item.quality
+    //       }
+    //     } else {
+    //       if (item.quality < 50) {
+    //         item.quality = item.quality + 1
+    //       }
+    //     }
+    //   }
     }
 
     return this.items;

--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -42,7 +42,6 @@ export class GildedRose {
 
   updateQuality() {
     for (let item of this.items) {
-
       switch (item.name) {
         case Items.Brie:
           if (item.sellIn <= 0) {
@@ -68,6 +67,8 @@ export class GildedRose {
           // do not change item as it is legendary
           break;
         case Items.Conjured:
+          // making the assumption that because "Conjured" items decrease in value twice as fast,
+          // the amount of quality decreased after passing the sell by also doubles
           if (item.sellIn <=0) {
             item = decreaseQuality(item, 4);
           } else {
@@ -84,51 +85,6 @@ export class GildedRose {
           item.sellIn --;
           break;
       }
-
-
-    //   if (item.name != Items.Brie && item.name != Items.Pass) {
-    //     if (item.quality > 0) {
-    //       if (item.name != Items.Sulfuras) {
-    //         item.quality = item.quality - 1
-    //       }
-    //     }
-    //   } else {
-    //     if (item.quality < 50) {
-    //       item.quality = item.quality + 1
-    //       if (item.name == Items.Pass) {
-    //         if (item.sellIn < 11) {
-    //           if (item.quality < 50) {
-    //             item.quality = item.quality + 1
-    //           }
-    //         }
-    //         if (item.sellIn < 6) {
-    //           if (item.quality < 50) {
-    //             item.quality = item.quality + 1
-    //           }
-    //         }
-    //       }
-    //     }
-    //   }
-    //   if (item.name != Items.Sulfuras) {
-    //     item.sellIn = item.sellIn - 1;
-    //   }
-    //   if (item.sellIn < 0) {
-    //     if (item.name != Items.Brie) {
-    //       if (item.name != Items.Pass) {
-    //         if (item.quality > 0) {
-    //           if (item.name != Items.Sulfuras) {
-    //             item.quality = item.quality - 1
-    //           }
-    //         }
-    //       } else {
-    //         item.quality = item.quality - item.quality
-    //       }
-    //     } else {
-    //       if (item.quality < 50) {
-    //         item.quality = item.quality + 1
-    //       }
-    //     }
-    //   }
     }
 
     return this.items;

--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -16,6 +16,22 @@ enum Items {
   Sulfuras = 'Sulfuras, Hand of Ragnaros',
 }
 
+const increaseQuality = (item: Item, increaseBy: number): Item => {
+  item.quality += increaseBy;
+  if (item.quality >= 50) {
+    item.quality = 50;
+  }
+  return item;
+}
+
+const decreaseQuality = (item: Item, decreaseBy: number): Item => {
+  item.quality -= decreaseBy;
+  if (item.quality < 0){
+    item.quality = 0;
+  }
+  return item;
+}
+
 export class GildedRose {
   items: Array<Item>;
 

--- a/TypeScript/app/helpers.ts
+++ b/TypeScript/app/helpers.ts
@@ -6,7 +6,7 @@ export enum Items {
   Sulfuras = 'Sulfuras, Hand of Ragnaros',
   Conjured = 'Conjured Mana Cake',
 }
-  
+
 export const increaseQuality = (item: Item, increaseBy: number): Item => {
   item.quality += increaseBy;
   if (item.quality >= 50) {
@@ -14,13 +14,59 @@ export const increaseQuality = (item: Item, increaseBy: number): Item => {
   }
   return item;
 }
-  
+
 export const decreaseQuality = (item: Item, decreaseBy: number): Item => {
   item.quality -= decreaseBy;
-  if (item.quality < 0){
+  if (item.quality < 0) {
     item.quality = 0;
   }
   return item;
 }
-  
+
+export const updateBrie = (item: Item): Item => {
+  if (item.sellIn <= 0) {
+    item = increaseQuality(item, 2);
+  } else {
+    item = increaseQuality(item, 1);
+  }
+  item.sellIn --;
+  return item;
+}
+
+export const updatePass = (item: Item): Item => {
+  if (item.sellIn <= 0) {
+    item.quality = 0;
+  } else if (item.sellIn <= 5) {
+    item = increaseQuality(item, 3);
+  } else if (item.sellIn <= 10) {
+    item = increaseQuality(item, 2);
+  } else {
+    item = increaseQuality(item, 1);
+  }
+  item.sellIn --;
+  return item;
+}
+
+export const updateConjured = (item: Item): Item => {
+  // making the assumption that because "Conjured" items decrease in value
+  // twice as fast, the amount of quality decreased after passing the sell
+  // by also doubles
+  if (item.sellIn <=0) {
+    item = decreaseQuality(item, 4);
+  } else {
+    item = decreaseQuality(item, 2);
+  }
+  item.sellIn --;
+  return item;
+}
+
+export const updateDefault = (item: Item): Item => {
+  if (item.sellIn <= 0) {
+    item = decreaseQuality(item, 2);
+  } else {
+    item = decreaseQuality(item, 1);
+  }
+  item.sellIn --;
+  return item;
+}
   

--- a/TypeScript/app/helpers.ts
+++ b/TypeScript/app/helpers.ts
@@ -1,0 +1,26 @@
+import { Item } from "./gilded-rose";
+
+export enum Items {
+  Brie = 'Aged Brie',
+  Pass = 'Backstage passes to a TAFKAL80ETC concert',
+  Sulfuras = 'Sulfuras, Hand of Ragnaros',
+  Conjured = 'Conjured Mana Cake',
+}
+  
+export const increaseQuality = (item: Item, increaseBy: number): Item => {
+  item.quality += increaseBy;
+  if (item.quality >= 50) {
+    item.quality = 50;
+  }
+  return item;
+}
+  
+export const decreaseQuality = (item: Item, decreaseBy: number): Item => {
+  item.quality -= decreaseBy;
+  if (item.quality < 0){
+    item.quality = 0;
+  }
+  return item;
+}
+  
+  

--- a/TypeScript/test/jest/__snapshots__/approvals.spec.ts.snap
+++ b/TypeScript/test/jest/__snapshots__/approvals.spec.ts.snap
@@ -1,0 +1,388 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Gilded Rose Approval should foo 1`] = `
+[
+  Item {
+    "name": "foo",
+    "quality": 0,
+    "sellIn": -1,
+  },
+]
+`;
+
+exports[`Gilded Rose Approval should thirtyDays 1`] = `
+"OMGHAI!
+-------- day 0 --------
+name, sellIn, quality
++5 Dexterity Vest, 10, 20
+Aged Brie, 2, 0
+Elixir of the Mongoose, 5, 7
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 15, 20
+Backstage passes to a TAFKAL80ETC concert, 10, 49
+Backstage passes to a TAFKAL80ETC concert, 5, 49
+Conjured Mana Cake, 3, 6
+
+-------- day 1 --------
+name, sellIn, quality
++5 Dexterity Vest, 9, 19
+Aged Brie, 1, 1
+Elixir of the Mongoose, 4, 6
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 14, 21
+Backstage passes to a TAFKAL80ETC concert, 9, 50
+Backstage passes to a TAFKAL80ETC concert, 4, 50
+Conjured Mana Cake, 2, 5
+
+-------- day 2 --------
+name, sellIn, quality
++5 Dexterity Vest, 8, 18
+Aged Brie, 0, 2
+Elixir of the Mongoose, 3, 5
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 13, 22
+Backstage passes to a TAFKAL80ETC concert, 8, 50
+Backstage passes to a TAFKAL80ETC concert, 3, 50
+Conjured Mana Cake, 1, 4
+
+-------- day 3 --------
+name, sellIn, quality
++5 Dexterity Vest, 7, 17
+Aged Brie, -1, 4
+Elixir of the Mongoose, 2, 4
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 12, 23
+Backstage passes to a TAFKAL80ETC concert, 7, 50
+Backstage passes to a TAFKAL80ETC concert, 2, 50
+Conjured Mana Cake, 0, 3
+
+-------- day 4 --------
+name, sellIn, quality
++5 Dexterity Vest, 6, 16
+Aged Brie, -2, 6
+Elixir of the Mongoose, 1, 3
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 11, 24
+Backstage passes to a TAFKAL80ETC concert, 6, 50
+Backstage passes to a TAFKAL80ETC concert, 1, 50
+Conjured Mana Cake, -1, 1
+
+-------- day 5 --------
+name, sellIn, quality
++5 Dexterity Vest, 5, 15
+Aged Brie, -3, 8
+Elixir of the Mongoose, 0, 2
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 10, 25
+Backstage passes to a TAFKAL80ETC concert, 5, 50
+Backstage passes to a TAFKAL80ETC concert, 0, 50
+Conjured Mana Cake, -2, 0
+
+-------- day 6 --------
+name, sellIn, quality
++5 Dexterity Vest, 4, 14
+Aged Brie, -4, 10
+Elixir of the Mongoose, -1, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 9, 27
+Backstage passes to a TAFKAL80ETC concert, 4, 50
+Backstage passes to a TAFKAL80ETC concert, -1, 0
+Conjured Mana Cake, -3, 0
+
+-------- day 7 --------
+name, sellIn, quality
++5 Dexterity Vest, 3, 13
+Aged Brie, -5, 12
+Elixir of the Mongoose, -2, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 8, 29
+Backstage passes to a TAFKAL80ETC concert, 3, 50
+Backstage passes to a TAFKAL80ETC concert, -2, 0
+Conjured Mana Cake, -4, 0
+
+-------- day 8 --------
+name, sellIn, quality
++5 Dexterity Vest, 2, 12
+Aged Brie, -6, 14
+Elixir of the Mongoose, -3, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 7, 31
+Backstage passes to a TAFKAL80ETC concert, 2, 50
+Backstage passes to a TAFKAL80ETC concert, -3, 0
+Conjured Mana Cake, -5, 0
+
+-------- day 9 --------
+name, sellIn, quality
++5 Dexterity Vest, 1, 11
+Aged Brie, -7, 16
+Elixir of the Mongoose, -4, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 6, 33
+Backstage passes to a TAFKAL80ETC concert, 1, 50
+Backstage passes to a TAFKAL80ETC concert, -4, 0
+Conjured Mana Cake, -6, 0
+
+-------- day 10 --------
+name, sellIn, quality
++5 Dexterity Vest, 0, 10
+Aged Brie, -8, 18
+Elixir of the Mongoose, -5, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 5, 35
+Backstage passes to a TAFKAL80ETC concert, 0, 50
+Backstage passes to a TAFKAL80ETC concert, -5, 0
+Conjured Mana Cake, -7, 0
+
+-------- day 11 --------
+name, sellIn, quality
++5 Dexterity Vest, -1, 8
+Aged Brie, -9, 20
+Elixir of the Mongoose, -6, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 4, 38
+Backstage passes to a TAFKAL80ETC concert, -1, 0
+Backstage passes to a TAFKAL80ETC concert, -6, 0
+Conjured Mana Cake, -8, 0
+
+-------- day 12 --------
+name, sellIn, quality
++5 Dexterity Vest, -2, 6
+Aged Brie, -10, 22
+Elixir of the Mongoose, -7, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 3, 41
+Backstage passes to a TAFKAL80ETC concert, -2, 0
+Backstage passes to a TAFKAL80ETC concert, -7, 0
+Conjured Mana Cake, -9, 0
+
+-------- day 13 --------
+name, sellIn, quality
++5 Dexterity Vest, -3, 4
+Aged Brie, -11, 24
+Elixir of the Mongoose, -8, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 2, 44
+Backstage passes to a TAFKAL80ETC concert, -3, 0
+Backstage passes to a TAFKAL80ETC concert, -8, 0
+Conjured Mana Cake, -10, 0
+
+-------- day 14 --------
+name, sellIn, quality
++5 Dexterity Vest, -4, 2
+Aged Brie, -12, 26
+Elixir of the Mongoose, -9, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 1, 47
+Backstage passes to a TAFKAL80ETC concert, -4, 0
+Backstage passes to a TAFKAL80ETC concert, -9, 0
+Conjured Mana Cake, -11, 0
+
+-------- day 15 --------
+name, sellIn, quality
++5 Dexterity Vest, -5, 0
+Aged Brie, -13, 28
+Elixir of the Mongoose, -10, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, 0, 50
+Backstage passes to a TAFKAL80ETC concert, -5, 0
+Backstage passes to a TAFKAL80ETC concert, -10, 0
+Conjured Mana Cake, -12, 0
+
+-------- day 16 --------
+name, sellIn, quality
++5 Dexterity Vest, -6, 0
+Aged Brie, -14, 30
+Elixir of the Mongoose, -11, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, -1, 0
+Backstage passes to a TAFKAL80ETC concert, -6, 0
+Backstage passes to a TAFKAL80ETC concert, -11, 0
+Conjured Mana Cake, -13, 0
+
+-------- day 17 --------
+name, sellIn, quality
++5 Dexterity Vest, -7, 0
+Aged Brie, -15, 32
+Elixir of the Mongoose, -12, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, -2, 0
+Backstage passes to a TAFKAL80ETC concert, -7, 0
+Backstage passes to a TAFKAL80ETC concert, -12, 0
+Conjured Mana Cake, -14, 0
+
+-------- day 18 --------
+name, sellIn, quality
++5 Dexterity Vest, -8, 0
+Aged Brie, -16, 34
+Elixir of the Mongoose, -13, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, -3, 0
+Backstage passes to a TAFKAL80ETC concert, -8, 0
+Backstage passes to a TAFKAL80ETC concert, -13, 0
+Conjured Mana Cake, -15, 0
+
+-------- day 19 --------
+name, sellIn, quality
++5 Dexterity Vest, -9, 0
+Aged Brie, -17, 36
+Elixir of the Mongoose, -14, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, -4, 0
+Backstage passes to a TAFKAL80ETC concert, -9, 0
+Backstage passes to a TAFKAL80ETC concert, -14, 0
+Conjured Mana Cake, -16, 0
+
+-------- day 20 --------
+name, sellIn, quality
++5 Dexterity Vest, -10, 0
+Aged Brie, -18, 38
+Elixir of the Mongoose, -15, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, -5, 0
+Backstage passes to a TAFKAL80ETC concert, -10, 0
+Backstage passes to a TAFKAL80ETC concert, -15, 0
+Conjured Mana Cake, -17, 0
+
+-------- day 21 --------
+name, sellIn, quality
++5 Dexterity Vest, -11, 0
+Aged Brie, -19, 40
+Elixir of the Mongoose, -16, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, -6, 0
+Backstage passes to a TAFKAL80ETC concert, -11, 0
+Backstage passes to a TAFKAL80ETC concert, -16, 0
+Conjured Mana Cake, -18, 0
+
+-------- day 22 --------
+name, sellIn, quality
++5 Dexterity Vest, -12, 0
+Aged Brie, -20, 42
+Elixir of the Mongoose, -17, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, -7, 0
+Backstage passes to a TAFKAL80ETC concert, -12, 0
+Backstage passes to a TAFKAL80ETC concert, -17, 0
+Conjured Mana Cake, -19, 0
+
+-------- day 23 --------
+name, sellIn, quality
++5 Dexterity Vest, -13, 0
+Aged Brie, -21, 44
+Elixir of the Mongoose, -18, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, -8, 0
+Backstage passes to a TAFKAL80ETC concert, -13, 0
+Backstage passes to a TAFKAL80ETC concert, -18, 0
+Conjured Mana Cake, -20, 0
+
+-------- day 24 --------
+name, sellIn, quality
++5 Dexterity Vest, -14, 0
+Aged Brie, -22, 46
+Elixir of the Mongoose, -19, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, -9, 0
+Backstage passes to a TAFKAL80ETC concert, -14, 0
+Backstage passes to a TAFKAL80ETC concert, -19, 0
+Conjured Mana Cake, -21, 0
+
+-------- day 25 --------
+name, sellIn, quality
++5 Dexterity Vest, -15, 0
+Aged Brie, -23, 48
+Elixir of the Mongoose, -20, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, -10, 0
+Backstage passes to a TAFKAL80ETC concert, -15, 0
+Backstage passes to a TAFKAL80ETC concert, -20, 0
+Conjured Mana Cake, -22, 0
+
+-------- day 26 --------
+name, sellIn, quality
++5 Dexterity Vest, -16, 0
+Aged Brie, -24, 50
+Elixir of the Mongoose, -21, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, -11, 0
+Backstage passes to a TAFKAL80ETC concert, -16, 0
+Backstage passes to a TAFKAL80ETC concert, -21, 0
+Conjured Mana Cake, -23, 0
+
+-------- day 27 --------
+name, sellIn, quality
++5 Dexterity Vest, -17, 0
+Aged Brie, -25, 50
+Elixir of the Mongoose, -22, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, -12, 0
+Backstage passes to a TAFKAL80ETC concert, -17, 0
+Backstage passes to a TAFKAL80ETC concert, -22, 0
+Conjured Mana Cake, -24, 0
+
+-------- day 28 --------
+name, sellIn, quality
++5 Dexterity Vest, -18, 0
+Aged Brie, -26, 50
+Elixir of the Mongoose, -23, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, -13, 0
+Backstage passes to a TAFKAL80ETC concert, -18, 0
+Backstage passes to a TAFKAL80ETC concert, -23, 0
+Conjured Mana Cake, -25, 0
+
+-------- day 29 --------
+name, sellIn, quality
++5 Dexterity Vest, -19, 0
+Aged Brie, -27, 50
+Elixir of the Mongoose, -24, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, -14, 0
+Backstage passes to a TAFKAL80ETC concert, -19, 0
+Backstage passes to a TAFKAL80ETC concert, -24, 0
+Conjured Mana Cake, -26, 0
+
+-------- day 30 --------
+name, sellIn, quality
++5 Dexterity Vest, -20, 0
+Aged Brie, -28, 50
+Elixir of the Mongoose, -25, 0
+Sulfuras, Hand of Ragnaros, 0, 80
+Sulfuras, Hand of Ragnaros, -1, 80
+Backstage passes to a TAFKAL80ETC concert, -15, 0
+Backstage passes to a TAFKAL80ETC concert, -20, 0
+Backstage passes to a TAFKAL80ETC concert, -25, 0
+Conjured Mana Cake, -27, 0
+
+"
+`;

--- a/TypeScript/test/jest/gilded-rose.spec.ts
+++ b/TypeScript/test/jest/gilded-rose.spec.ts
@@ -4,6 +4,6 @@ describe('Gilded Rose', () => {
   it('should foo', () => {
     const gildedRose = new GildedRose([new Item('foo', 0, 0)]);
     const items = gildedRose.updateQuality();
-    expect(items[0].name).toBe('fixme');
+    expect(items[0].name).toBe('foo');
   });
 });

--- a/TypeScript/test/jest/gilded-rose.spec.ts
+++ b/TypeScript/test/jest/gilded-rose.spec.ts
@@ -4,6 +4,6 @@ describe('Gilded Rose', () => {
   it('should foo', () => {
     const gildedRose = new GildedRose([new Item('foo', 0, 0)]);
     const items = gildedRose.updateQuality();
-    expect(items[0].name).toBe('foo');
+    expect(items[0].name).toBe('fixme');
   });
 });

--- a/TypeScript/test/jest/gilded-rose.spec.ts
+++ b/TypeScript/test/jest/gilded-rose.spec.ts
@@ -72,4 +72,16 @@ describe('Gilded Rose', () => {
     const items = gildedRose.updateQuality();
     expect(items[0].quality).toBe(0);
   });
+
+  it('should degrade "Conjured" items quality twice as fast', () => {
+    const gildedRose = new GildedRose([new Item('Conjured mana cake', 4, 8)]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].quality).toBe(6);
+  });
+
+  it('should not degrade "Conjured" items quality below 0', () => {
+    const gildedRose = new GildedRose([new Item('Conjured mana cake', 4, 1)]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].quality).toBe(0);
+  });
 });

--- a/TypeScript/test/jest/gilded-rose.spec.ts
+++ b/TypeScript/test/jest/gilded-rose.spec.ts
@@ -74,14 +74,20 @@ describe('Gilded Rose', () => {
   });
 
   it('should degrade "Conjured" items quality twice as fast', () => {
-    const gildedRose = new GildedRose([new Item('Conjured mana cake', 4, 8)]);
+    const gildedRose = new GildedRose([new Item('Conjured Mana Cake', 4, 8)]);
     const items = gildedRose.updateQuality();
     expect(items[0].quality).toBe(6);
   });
 
   it('should not degrade "Conjured" items quality below 0', () => {
-    const gildedRose = new GildedRose([new Item('Conjured mana cake', 4, 1)]);
+    const gildedRose = new GildedRose([new Item('Conjured Mana Cake', 4, 1)]);
     const items = gildedRose.updateQuality();
     expect(items[0].quality).toBe(0);
+  });
+
+  it('should degrade "Conjured" items quality by 4 after sell by', () => {
+    const gildedRose = new GildedRose([new Item('Conjured Mana Cake', -4, 10)]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].quality).toBe(6);
   });
 });

--- a/TypeScript/test/jest/gilded-rose.spec.ts
+++ b/TypeScript/test/jest/gilded-rose.spec.ts
@@ -30,4 +30,22 @@ describe('Gilded Rose', () => {
     const items = gildedRose.updateQuality();
     expect(items[0].quality).toBe(80);
   });
+
+  it('should increase quality for "Aged Brie" as it ages', () => {
+    const gildedRose = new GildedRose([new Item('Aged Brie', 3, 10)]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].quality).toBe(11);
+  });
+
+  it('should increase quality for "Aged Brie" by 2 when past the sell by', () => {
+    const gildedRose = new GildedRose([new Item('Aged Brie', -1, 10)]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].quality).toBe(12);
+  });
+
+  it('should never increase the quality of an item to more than 50', () => {
+    const gildedRose = new GildedRose([new Item('Aged Brie', 7, 50)]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].quality).toBe(50);
+  });
 });

--- a/TypeScript/test/jest/gilded-rose.spec.ts
+++ b/TypeScript/test/jest/gilded-rose.spec.ts
@@ -24,4 +24,10 @@ describe('Gilded Rose', () => {
     const items = gildedRose.updateQuality();
     expect(items[0].quality).toBe(8);
   });
+
+  it('should never change the quality of "Sulfuras"', () => {
+    const gildedRose = new GildedRose([new Item('Sulfuras, Hand of Ragnaros', -1, 80)]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].quality).toBe(80);
+  });
 });

--- a/TypeScript/test/jest/gilded-rose.spec.ts
+++ b/TypeScript/test/jest/gilded-rose.spec.ts
@@ -48,4 +48,28 @@ describe('Gilded Rose', () => {
     const items = gildedRose.updateQuality();
     expect(items[0].quality).toBe(50);
   });
+
+  it('should increase the quality of "Backstage Passes" as it ages', () => {
+    const gildedRose = new GildedRose([new Item('Backstage passes to a TAFKAL80ETC concert', 20, 5)]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].quality).toBe(6);
+  });
+
+  it('should increase the quality of "Backstage Passes" by 2 when there are 10 days or less left', () => {
+    const gildedRose = new GildedRose([new Item('Backstage passes to a TAFKAL80ETC concert', 10, 5)]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].quality).toBe(7);
+  });
+
+  it('should increase the quality of "Backstage Passes" by 3 when there are 5 days or less left', () => {
+    const gildedRose = new GildedRose([new Item('Backstage passes to a TAFKAL80ETC concert', 4, 5)]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].quality).toBe(8);
+  });
+
+  it('should decrease the quality of "Backstage Passes" to 0 when the sell by date has passed', () => {
+    const gildedRose = new GildedRose([new Item('Backstage passes to a TAFKAL80ETC concert', 0, 5)]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].quality).toBe(0);
+  });
 });

--- a/TypeScript/test/jest/gilded-rose.spec.ts
+++ b/TypeScript/test/jest/gilded-rose.spec.ts
@@ -1,93 +1,106 @@
 import { Item, GildedRose } from '@/gilded-rose';
+import { Items } from '@/helpers';
 
 describe('Gilded Rose', () => {
+  const ELIXIR = 'Elixir of the Mongoose';
+
   it('should foo', () => {
     const gildedRose = new GildedRose([new Item('foo', 0, 0)]);
     const items = gildedRose.updateQuality();
     expect(items[0].name).toBe('foo');
   });
+
+  describe('Default items', () => {
+    it('should decrease quality of "Elixir" items by 1', () => {
+      const gildedRose = new GildedRose([new Item(ELIXIR, 18, 7)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(6);
+    });
+    
+    it('should not degrade "Elixir" items quality below 0', () => {
+      const gildedRose = new GildedRose([new Item(ELIXIR, 4, 0)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(0);
+    });
   
-  it('should decrease quality of "Elixir" items by 1', () => {
-    const gildedRose = new GildedRose([new Item('Elixir of the Mongoose', 18, 7)]);
-    const items = gildedRose.updateQuality();
-    expect(items[0].quality).toBe(6);
+    it('should degrade quality twice as fast after the sell by date has passed', () => {
+      const gildedRose = new GildedRose([new Item(ELIXIR, 0, 10)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(8);
+    });
   });
+
+  describe('Sulfuras items', () => {
+    it('should never change the quality of "Sulfuras"', () => {
+      const gildedRose = new GildedRose([new Item(Items.Sulfuras, -1, 80)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(80);
+    });
+  });
+
+  describe('Aged Brie items', () => {
+    it('should increase quality for "Aged Brie" as it ages', () => {
+      const gildedRose = new GildedRose([new Item(Items.Brie, 3, 10)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(11);
+    });
   
-  it('should not degrade "Elixir" items quality below 0', () => {
-    const gildedRose = new GildedRose([new Item('Elixir of the Mongoose', 4, 0)]);
-    const items = gildedRose.updateQuality();
-    expect(items[0].quality).toBe(0);
+    it('should increase quality for "Aged Brie" by 2 when past the sell by', () => {
+      const gildedRose = new GildedRose([new Item(Items.Brie, -1, 10)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(12);
+    });
+  
+    it('should never increase the quality of an item to more than 50', () => {
+      const gildedRose = new GildedRose([new Item(Items.Brie, 7, 50)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(50);
+    });
   });
 
-  it('should degrade quality twice as fast after the sell by date has passed', () => {
-    const gildedRose = new GildedRose([new Item('Elixir of the Mongoose', 0, 10)]);
-    const items = gildedRose.updateQuality();
-    expect(items[0].quality).toBe(8);
+  describe('Backstage Passes items', () => {
+    it('should increase the quality of "Backstage Passes" as it ages', () => {
+      const gildedRose = new GildedRose([new Item(Items.Pass, 20, 5)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(6);
+    });
+  
+    it('should increase the quality of "Backstage Passes" by 2 when there are 10 days or less left', () => {
+      const gildedRose = new GildedRose([new Item(Items.Pass, 10, 5)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(7);
+    });
+  
+    it('should increase the quality of "Backstage Passes" by 3 when there are 5 days or less left', () => {
+      const gildedRose = new GildedRose([new Item(Items.Pass, 4, 5)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(8);
+    });
+  
+    it('should decrease the quality of "Backstage Passes" to 0 when the sell by date has passed', () => {
+      const gildedRose = new GildedRose([new Item(Items.Pass, 0, 5)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(0);
+    });
   });
 
-  it('should never change the quality of "Sulfuras"', () => {
-    const gildedRose = new GildedRose([new Item('Sulfuras, Hand of Ragnaros', -1, 80)]);
-    const items = gildedRose.updateQuality();
-    expect(items[0].quality).toBe(80);
-  });
-
-  it('should increase quality for "Aged Brie" as it ages', () => {
-    const gildedRose = new GildedRose([new Item('Aged Brie', 3, 10)]);
-    const items = gildedRose.updateQuality();
-    expect(items[0].quality).toBe(11);
-  });
-
-  it('should increase quality for "Aged Brie" by 2 when past the sell by', () => {
-    const gildedRose = new GildedRose([new Item('Aged Brie', -1, 10)]);
-    const items = gildedRose.updateQuality();
-    expect(items[0].quality).toBe(12);
-  });
-
-  it('should never increase the quality of an item to more than 50', () => {
-    const gildedRose = new GildedRose([new Item('Aged Brie', 7, 50)]);
-    const items = gildedRose.updateQuality();
-    expect(items[0].quality).toBe(50);
-  });
-
-  it('should increase the quality of "Backstage Passes" as it ages', () => {
-    const gildedRose = new GildedRose([new Item('Backstage passes to a TAFKAL80ETC concert', 20, 5)]);
-    const items = gildedRose.updateQuality();
-    expect(items[0].quality).toBe(6);
-  });
-
-  it('should increase the quality of "Backstage Passes" by 2 when there are 10 days or less left', () => {
-    const gildedRose = new GildedRose([new Item('Backstage passes to a TAFKAL80ETC concert', 10, 5)]);
-    const items = gildedRose.updateQuality();
-    expect(items[0].quality).toBe(7);
-  });
-
-  it('should increase the quality of "Backstage Passes" by 3 when there are 5 days or less left', () => {
-    const gildedRose = new GildedRose([new Item('Backstage passes to a TAFKAL80ETC concert', 4, 5)]);
-    const items = gildedRose.updateQuality();
-    expect(items[0].quality).toBe(8);
-  });
-
-  it('should decrease the quality of "Backstage Passes" to 0 when the sell by date has passed', () => {
-    const gildedRose = new GildedRose([new Item('Backstage passes to a TAFKAL80ETC concert', 0, 5)]);
-    const items = gildedRose.updateQuality();
-    expect(items[0].quality).toBe(0);
-  });
-
-  it('should degrade "Conjured" items quality twice as fast', () => {
-    const gildedRose = new GildedRose([new Item('Conjured Mana Cake', 4, 8)]);
-    const items = gildedRose.updateQuality();
-    expect(items[0].quality).toBe(6);
-  });
-
-  it('should not degrade "Conjured" items quality below 0', () => {
-    const gildedRose = new GildedRose([new Item('Conjured Mana Cake', 4, 1)]);
-    const items = gildedRose.updateQuality();
-    expect(items[0].quality).toBe(0);
-  });
-
-  it('should degrade "Conjured" items quality by 4 after sell by', () => {
-    const gildedRose = new GildedRose([new Item('Conjured Mana Cake', -4, 10)]);
-    const items = gildedRose.updateQuality();
-    expect(items[0].quality).toBe(6);
+  describe('Conjured items', () => {
+    it('should degrade "Conjured" items quality twice as fast', () => {
+      const gildedRose = new GildedRose([new Item(Items.Conjured, 4, 8)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(6);
+    });
+  
+    it('should not degrade "Conjured" items quality below 0', () => {
+      const gildedRose = new GildedRose([new Item(Items.Conjured, 4, 1)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(0);
+    });
+  
+    it('should degrade "Conjured" items quality by 4 after sell by', () => {
+      const gildedRose = new GildedRose([new Item(Items.Conjured, -4, 10)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(6);
+    });
   });
 });

--- a/TypeScript/test/jest/gilded-rose.spec.ts
+++ b/TypeScript/test/jest/gilded-rose.spec.ts
@@ -6,4 +6,22 @@ describe('Gilded Rose', () => {
     const items = gildedRose.updateQuality();
     expect(items[0].name).toBe('foo');
   });
+  
+  it('should decrease quality of "Elixir" items by 1', () => {
+    const gildedRose = new GildedRose([new Item('Elixir of the Mongoose', 18, 7)]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].quality).toBe(6);
+  });
+  
+  it('should not degrade "Elixir" items quality below 0', () => {
+    const gildedRose = new GildedRose([new Item('Elixir of the Mongoose', 4, 0)]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].quality).toBe(0);
+  });
+
+  it('should degrade quality twice as fast after the sell by date has passed', () => {
+    const gildedRose = new GildedRose([new Item('Elixir of the Mongoose', 0, 10)]);
+    const items = gildedRose.updateQuality();
+    expect(items[0].quality).toBe(8);
+  });
 });


### PR DESCRIPTION
Initially I started with an attempt to reorganize the nested if statements, but found them so tangled that I decided to start over with a different approach.

- Replaced magic strings and lengthy elements (`this.items[i]`) that were being reused
- Wrote logic to handle the changes in quality and the made a shelled out switch statement
- Wrote test cases for individual item types, starting with the default items (items without special cases), and recreated logic for each of those item types within the switch
- Once all the original items were accounted for, wrote tests and new logic for the new "Conjured" items
- Sorted code into a `helpers.ts` file to be called in `gilded-rose.ts`